### PR TITLE
Fix UZH Login issue

### DIFF
--- a/src/asvz_bot.py
+++ b/src/asvz_bot.py
@@ -32,7 +32,7 @@ CREDENTIALS_PW = "password"
 # organisation name as dispay by SwitchAAI
 ORGANISATIONS = {
     "ETH": "ETH Zürich",
-    "Uni Zürich": "University of Zurich",
+    "University of Zurich": "University of Zurich",
     "ZHAW": "ZHAW - Zürcher Hochschule für Angewandte Wissenschaften",
 }
 


### PR DESCRIPTION
Login issue with UZH login is fixed here. Problem does *not* occur with "ETH" or "ZHAW" since the real name in the Switch AAI dropdown menu starts with these letters, but "University of Zurich" does not start with "Uni Zürich".