### PR TITLE
Make script language independent (and fix UZH name issue)

### DIFF
--- a/src/asvz_bot.py
+++ b/src/asvz_bot.py
@@ -79,7 +79,7 @@ class CredentialsManager:
                 password = getpass.getpass("Organisation password:")
 
             self.credentials = {
-                CREDENTIALS_ORG: org,
+                CREDENTIALS_ORG: ORGANISATIONS[org],
                 CREDENTIALS_UNAME: uname,
                 CREDENTIALS_PW: password,
             }
@@ -88,7 +88,7 @@ class CredentialsManager:
                 "Overwriting credentials loaded from local store with arguments"
             )
             if org is not None:
-                self.credentials[CREDENTIALS_ORG] = org
+                self.credentials[CREDENTIALS_ORG] = ORGANISATIONS[org]
             if uname is not None:
                 self.credentials[CREDENTIALS_UNAME] = uname
 
@@ -490,7 +490,7 @@ def main():
     creds = None
     try:
         creds = CredentialsManager(
-            ORGANISATIONS[args.organisation], args.username, args.password, args.save_credentials
+            args.organisation, args.username, args.password, args.save_credentials
         ).get()
     except AsvzBotException as e:
         logging.error(e)

--- a/src/asvz_bot.py
+++ b/src/asvz_bot.py
@@ -31,8 +31,8 @@ CREDENTIALS_PW = "password"
 
 # organisation name as displayed by SwitchAAI
 ORGANISATIONS = {
-    "ETH": "ETH Zurich",
-    "UZH": "University of Zurich",
+    "ETH": "ETH Zürich",
+    "UZH": "Universität Zürich",
     "ZHAW": "ZHAW - Zürcher Hochschule für Angewandte Wissenschaften",
 }
 
@@ -182,6 +182,7 @@ class AsvzEnroller:
         options = Options()
         options.add_argument("--private")
         options.add_argument("--headless")
+        options.add_experimental_option('prefs', {'intl.accept_languages': 'de,de_CH'})
         return webdriver.Chrome(
             chromedriver,
             options=options,

--- a/src/asvz_bot.py
+++ b/src/asvz_bot.py
@@ -31,8 +31,8 @@ CREDENTIALS_PW = "password"
 
 # organisation name as dispay by SwitchAAI
 ORGANISATIONS = {
-    "ETH": "ETH Zürich",
-    "Uni Zürich": "University of Zurich",
+    "ETH": "ETH Zurich",
+    "UZH": "University of Zurich",
     "ZHAW": "ZHAW - Zürcher Hochschule für Angewandte Wissenschaften",
 }
 
@@ -489,7 +489,7 @@ def main():
     creds = None
     try:
         creds = CredentialsManager(
-            args.organisation, args.username, args.password, args.save_credentials
+            ORGANISATIONS[args.organisation], args.username, args.password, args.save_credentials
         ).get()
     except AsvzBotException as e:
         logging.error(e)

--- a/src/asvz_bot.py
+++ b/src/asvz_bot.py
@@ -29,7 +29,7 @@ CREDENTIALS_ORG = "organisation"
 CREDENTIALS_UNAME = "username"
 CREDENTIALS_PW = "password"
 
-# organisation name as dispay by SwitchAAI
+# organisation name as displayed by SwitchAAI
 ORGANISATIONS = {
     "ETH": "ETH Zurich",
     "UZH": "University of Zurich",


### PR DESCRIPTION
Make UZH to work again and script should now also work on operating systems with different languages, since chrome language in the script is manually set to de_CH. Without the language option, script fails on English operating systems (because SwitchAAI uses different names, e.g. "Universität Zürich" in German but "University of Zurich" in English).