### PR TITLE
Add information about authentication changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo contains a script to automatically enroll to ASVZ lessons
 - Save your credentials locally and reuse them on the next run
 - Note: 
     UZH, ZHAW and PHZH use SWITCH edu-ID as login (*email* + password).
-    ETH uses own login (*shortname* + password)
+    ETH uses own login (*nethz* + password)
     ASVZ uses own login (*ASVZ-ID* + password)
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This repo contains a script to automatically enroll to ASVZ lessons
   - PHZH
   - ASVZ
 - Save your credentials locally and reuse them on the next run
+- Note: 
+    UZH, ZHAW and PHZH use SWITCH edu-ID as login (*email* + password).
+    ETH uses own login (*shortname* + password)
+    ASVZ uses own login (*ASVZ-ID* + password)
 
 ## Run
 


### PR DESCRIPTION
UZH, ZHAW and PHZH changed authentication to SWITCH edu-ID which uses different login credentials than before. Shortname + password no longer works for these institutions, instead one has to enter the SWITCH edu-ID *email* + SWITCH edu-ID password and then it works again (after once manually logging in via browser and accept that SWITCH gets access to ASVZ account).